### PR TITLE
Implement basic support of dynamic libraries

### DIFF
--- a/src/robotremoteserver.py
+++ b/src/robotremoteserver.py
@@ -133,7 +133,11 @@ class RobotRemoteServer(SimpleXMLRPCServer):
         result = {'status': 'FAIL'}
         self._intercept_std_streams()
         try:
-            return_value = self._get_keyword(name)(*args, **kwargs)
+            lib_run_keyword = self._get_run_keyword()
+            if lib_run_keyword:
+                return_value = lib_run_keyword(name, *args, **kwargs)
+            else:
+                return_value = self._get_keyword(name)(*args, **kwargs)
         except:
             exc_type, exc_value, exc_tb = sys.exc_info()
             self._add_to_result(result, 'error',
@@ -198,6 +202,12 @@ class RobotRemoteServer(SimpleXMLRPCServer):
         if name == '__init__' and inspect.ismodule(self._library):
             return ''
         return inspect.getdoc(self._get_keyword(name)) or ''
+
+    def _get_run_keyword(self):
+        lib_run_keyword = getattr(self._library, 'run_keyword', None)
+        if not self._is_function_or_method(lib_run_keyword):
+            return None
+        return lib_run_keyword
 
     def _get_keyword(self, name):
         if name == 'stop_remote_server':

--- a/test/utest/test_robotremoteserver.py
+++ b/test/utest/test_robotremoteserver.py
@@ -56,6 +56,22 @@ class HybridLibrary:
         """Not returned by get_keyword_names"""
 
 
+class DynamicLibrary:
+
+    def __init__(self):
+        self.library = StaticLibrary()
+
+    def get_keyword_names(self):
+        return [n for n in dir(self.library) if n.endswith('_keyword')]
+
+    def run_keyword(self, name, *args, **kwargs):
+        return getattr(self.library, name)(*args, **kwargs)
+
+    @property
+    def streams(self):
+        return self.library.streams
+
+
 class TestStaticApi(unittest.TestCase):
     library = StaticLibrary()
 
@@ -130,6 +146,9 @@ class TestStaticApi(unittest.TestCase):
 class TestHybridApi(TestStaticApi):
     library = HybridLibrary()
 
+
+class TestDynamicApi(TestStaticApi):
+    library = DynamicLibrary()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Use `run_keyword` from library, if exists.