### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 MANIFEST
 .idea
 test/results
+temp
+*.egg-info
 *.pyc
+*.html
+*.xml
 build
+setup.cfg

--- a/example/examplelibrary.py
+++ b/example/examplelibrary.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+from six import string_types
 
 
 class ExampleRemoteLibrary(object):
@@ -14,8 +15,8 @@ class ExampleRemoteLibrary(object):
         return len([i for i in os.listdir(path) if not i.startswith('.')])
 
     def strings_should_be_equal(self, str1, str2):
-        print "Comparing '%s' to '%s'." % (str1, str2)
-        if not (isinstance(str1, basestring) and isinstance(str2, basestring)):
+        print("Comparing '%s' to '%s'." % (str1, str2))
+        if not (isinstance(str1, string_types) and isinstance(str2, string_types)):
             raise AssertionError("Given strings are not strings.")
         if str1 != str2:
             raise AssertionError("Given strings are not equal.")

--- a/example/examplelibrary.py
+++ b/example/examplelibrary.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os
 from six import string_types
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ CLASSIFIERS = '''
 Development Status :: 5 - Production/Stable
 License :: OSI Approved :: Apache Software License
 Operating System :: OS Independent
-Programming Language :: Python
+Programming Language :: Python :: 2
+Programming Language :: Python :: 3
 Topic :: Software Development :: Testing
 '''.strip().splitlines()
 CURDIR = dirname(abspath(__file__))
@@ -33,4 +34,5 @@ setup(
     classifiers      = CLASSIFIERS,
     package_dir      = {'': 'src'},
     py_modules       = [NAME],
+    install_requires = ['six']
 )

--- a/src/robotremoteserver.py
+++ b/src/robotremoteserver.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     Mapping = dict
 
-__version__ = '1.0.2.dev'
+__version__ = 'devel'
 
 BINARY = re.compile('[\x00-\x08\x0B\x0C\x0E-\x1F]')
 NON_ASCII = re.compile(b'[\x80-\xff]')

--- a/test/atest/argument_types.robot
+++ b/test/atest/argument_types.robot
@@ -19,7 +19,7 @@ Non-ASCII string
     u'\\u2603'
 
 Binary
-    '\\x00\\x01'
+    b'\\x00\\x01'
 
 Integer
     42
@@ -44,7 +44,7 @@ Custom object
     MyObject()            '<MyObject>'
     MyObject('xxx')       'xxx'
     MyObject(u'\\xe4')    u'\\xe4'
-    MyObject('\\x00')     '\\x00'
+    MyObject('\\x00')     b'\\x00'
 
 List
     \[]
@@ -57,7 +57,7 @@ List-like
     ()    []
     ('Hei', u'\\xe4iti', 63, (), None)    ['Hei', u'\\xe4iti', 63, [], '']
     set(['hello'])    ['hello']
-    xrange(5)    [0, 1, 2, 3, 4]
+    range(5)    [0, 1, 2, 3, 4]
 
 Dictionary
     {}

--- a/test/atest/returning.robot
+++ b/test/atest/returning.robot
@@ -11,23 +11,23 @@ Empty string
 
 ASCII string
     u'Hello, world!'
-    'Hello, world!'
+    b'Hello, world!'
 
 Non-ASCII String
     u'Hyv\\xe4'
     u'\\u2603'
 
 Non-ASCII Bytes
-    'Hyv\\xe4'
-    '\\x80\\xff'
+    b'Hyv\\xe4'
+    b'\\x80\\xff'
 
 Binary
-    '\\x00\\x01\\x02'
-    u'\\x00\\x01\\x02'
-    '\\x00\\xe4\\xff'
+    b'\\x00\\x01\\x02'
+    u'\\x00\\x01\\x02'    b'\\x00\\x01\\x02'
+    b'\\x00\\xe4\\xff'
 
 Unrepresentable binary
-    [Documentation]    FAIL ValueError: Cannot represent u'\\x00\\xe4\\xff' as binary.
+    [Documentation]    FAIL REGEXP: ValueError: Cannot represent (u'\\x00\\xe4\\xff'|'\x00дя') as binary.
     u'\\x00\\xe4\\xff'
 
 Integer
@@ -57,11 +57,11 @@ Custom object with non-ASCII representation
     MyObject(u'hyv\\xe4')    u'hyv\\xe4'
 
 Custom object with binary representation
-    MyObject('\\x00\\x01')    '\\x00\\x01'
+    MyObject('\\x00\\x01')    b'\\x00\\x01'
 
 List
     \[]
-    \['Hei', u'\\xe4iti', 63, True, '\\x00']
+    \['Hei', u'\\xe4iti', 63, True, '\\x00']    ['Hei', u'\\xe4iti', 63, True, b'\\x00']
     \[None, MyObject('xxx'), MyObject(u'\\xe4')]    ['', 'xxx', u'\\xe4']
     \[[0, [[]]], [1, 2], [[True], False], 'xxx']
 
@@ -81,18 +81,18 @@ Dictionary with non-ASCII keys and values
     {u'\\xe4': u'\\xe4', u'\\u2603': u'\\u2603'}
 
 Dictionary with non-ASCII byte keys is not supported
-    [Documentation]  FAIL TypeError: unhashable instance
-    {'\\xe4': 'value'}
+    [Documentation]  FAIL REGEXP: TypeError: unhashable .*
+    {b'\\xe4': 'value'}
 
 Dictionary with non-ASCII byte values
-    {'key': '\\xe4'}
+    {'key': b'\\xe4'}
 
 Dictionary with binary keys is not supported
-    [Documentation]  FAIL TypeError: unhashable instance
+    [Documentation]  FAIL REGEXP: TypeError: unhashable .*
     {'\\x00': 'value'}
 
 Dictionary with binary values
-    {'0': '\\x00', '1': '\\x01'}
+    {'0': b'\\x00', '1': b'\\x01'}
 
 Dictionary with non-string keys and values
     [Documentation]    XML-RPC supports only strings as keys so must convert them
@@ -102,7 +102,7 @@ Dictionary with non-string keys and values
 
 Mapping
     MyMapping()    {}
-    MyMapping({'a': 1, 2: 'b', u'\\xe4': '\\x00'})    {'a': 1, '2': 'b', u'\\xe4': '\\x00'}
+    MyMapping({'a': 1, 2: 'b', u'\\xe4': '\\x00'})    {'a': 1, '2': 'b', u'\\xe4': b'\\x00'}
     MyMapping({'x': MyMapping(), 'y': None})    {'x': {}, 'y': ''}
 
 *** Keywords ***

--- a/test/atest/returning.robot
+++ b/test/atest/returning.robot
@@ -70,7 +70,7 @@ List-like
     ()    []
     ('Hei', u'\\xe4iti', 63, (), None)    ['Hei', u'\\xe4iti', 63, [], '']
     set(['hello'])    ['hello']
-    xrange(5)    [0, 1, 2, 3, 4]
+    range(5)    [0, 1, 2, 3, 4]
 
 Dictionary
     {}

--- a/test/libs/arguments.py
+++ b/test/libs/arguments.py
@@ -1,3 +1,6 @@
+from six import string_types
+
+
 class Arguments(object):
 
     def argument_should_be_correct(self, argument, expected):
@@ -45,7 +48,7 @@ class Arguments(object):
         return ', '.join(self._format_arg(a) for a in args)
 
     def _format_arg(self, arg):
-        if isinstance(arg, basestring):
+        if isinstance(arg, string_types):
             return arg
         return '%s (%s)' % (arg, type(arg).__name__)
 

--- a/test/libs/basics.py
+++ b/test/libs/basics.py
@@ -28,7 +28,7 @@ class BasicCommunication(object):
         | Logging | Hello, world! |      |
         | Logging | Warning!!!    | WARN |
         """
-        print '*%s* %s' % (level, message)
+        print('*%s* %s' % (level, message))
 
     def returning(self, value):
         """This keyword returns the given `value`."""

--- a/test/libs/basics.py
+++ b/test/libs/basics.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 
 

--- a/test/libs/failing.py
+++ b/test/libs/failing.py
@@ -1,4 +1,7 @@
-import exceptions
+try:
+    import exceptions
+except ImportError:
+    import builtins as exceptions
 
 
 class Failures(object):

--- a/test/libs/logging.py
+++ b/test/libs/logging.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 
 

--- a/test/libs/logging.py
+++ b/test/libs/logging.py
@@ -12,21 +12,21 @@ class Logging(object):
         stream.write(message + '\n')
 
     def multiple_messages_with_different_levels(self):
-        print 'Info message'
-        print '*DEBUG* Debug message'
-        print '*INFO* Second info'
-        print 'this time with two lines'
-        print '*INFO* Third info'
-        print '*TRACE* This is ignored'
-        print '*WARN* Warning'
+        print('Info message')
+        print('*DEBUG* Debug message')
+        print('*INFO* Second info')
+        print('this time with two lines')
+        print('*INFO* Third info')
+        print('*TRACE* This is ignored')
+        print('*WARN* Warning')
 
     def logging_and_failing(self):
-        print '*INFO* This keyword will fail!'
-        print '*WARN* Run for your lives!!'
+        print('*INFO* This keyword will fail!')
+        print('*WARN* Run for your lives!!')
         raise AssertionError('Too slow')
 
     def logging_and_returning(self, logged, returned):
-        print logged
+        print(logged)
         return returned
 
     def logging_both_to_stdout_and_stderr(self, *messages):

--- a/test/run.py
+++ b/test/run.py
@@ -24,6 +24,7 @@ Examples:
   run.py jython atest/logging.robot  # One suite with Jython outside Windows
   run.py ipy --test NoMessage atest  # Specific test using IronPython
 """
+from __future__ import print_function
 
 import sys
 import subprocess

--- a/test/run.py
+++ b/test/run.py
@@ -49,11 +49,10 @@ if exists(results):
 mkdir(results)
 
 if not arguments:
-    print 'Running unit tests with %s.' % interpreter
+    print('Running unit tests with %s.' % interpreter)
     rc = subprocess.call([interpreter, join(curdir, 'utest', 'run.py')])
-    print
     if rc != 0:
-        print '%d unit test%s failed.' % (rc, 's' if rc != 1 else '')
+        print('%d unit test%s failed.' % (rc, 's' if rc != 1 else ''))
         sys.exit(rc)
     arguments = [join(curdir, 'atest')]
 
@@ -63,16 +62,14 @@ command = ['python', '-m', 'robot.run',
            '--metadata', 'Server_Interpreter:%s' % interpreter,
            '--noncritical', 'skip',
            '--output', output, '--log', 'NONE', '--report', 'NONE'] + arguments
-print 'Running acceptance tests with command:\n%s' % ' '.join(command)
+print('Running acceptance tests with command:\n%s' % ' '.join(command))
 subprocess.call(command)
-print
 
-print 'Verifying results.'
+print('Verifying results.')
 robotstatuschecker.process_output(output)
 rc = robot.rebot(output, outputdir=results, noncritical='skip')
-print
 if rc == 0:
-    print 'All tests passed.'
+    print('All tests passed.')
 else:
-    print '%d acceptance test%s failed.' % (rc, 's' if rc != 1 else '')
+    print('%d acceptance test%s failed.' % (rc, 's' if rc != 1 else ''))
 sys.exit(rc)


### PR DESCRIPTION
As described in issue #17 :)
- Based on the previous efforts by @molsky 
- Uses **six**, which can be changed of course ;)

All tests PASS with python2.
For python3 only those 3 atests need some further compatibility modifications in their compare logic:
- **Failing.Non-ASCII bytes**
  
  ```
  Expected error 'Hyv\xe4' but got 'Hyvä'.
  ```
- **Failing.Binary message**
  
  ```
  Expected error '..' but got 'b'\x00.\x01.\x02''.
  ```
- **Failing.Non-string message**
  
  ```
  Expected error '(u'\xe4 ', 42)' but got '('ä ', 42)'.
  ```
