### PR TITLE
Implemented support for @keyword decorator

### DIFF
--- a/test/atest/keyword_decorator.robot
+++ b/test/atest/keyword_decorator.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Resource          resource.robot
+Suite Setup       Start And Import Remote Library    keyword_decorator.py
+Suite Teardown    Stop Remote Library
+
+*** Test Cases ***
+Keyword with 2 arguments
+    Add 7 Copies Of Coffee To Cart
+
+When embedded name is empty keyword is still callable
+    Embedded name empty
+
+Tags added with keyword decorator
+    login  admin

--- a/test/libs/keyword_decorator.py
+++ b/test/libs/keyword_decorator.py
@@ -1,0 +1,22 @@
+from robot.api.deco import keyword
+
+class Arguments(object):
+
+    @keyword('Add ${quantity:\d+} Copies Of ${item} To Cart')
+    def add_copies_to_cart(self, quantity, item):
+        pass
+
+    @keyword('')
+    def embedded_name_empty(self):
+        pass
+
+    @keyword(tags=['tag1', 'tag2'])
+    def login(username, password):
+        '''
+        This is keyword documentation'''
+    
+if __name__ == '__main__':
+    import sys
+    from robotremoteserver import RobotRemoteServer
+
+    RobotRemoteServer(Arguments(), '127.0.0.1', *sys.argv[1:])


### PR DESCRIPTION
get_keyword_names populates the mapping from an 'embedded
argument name' to a 'function name'. Assumed is that
get_keyword_names is always called before run_keyword.

Tags passed to the decorator are added at the end of the keyword
documentation using Tags: tag1, tag2 syntax.

The test does not check if tag1 and tag2 have been added to the
keyword yet.

issue: #35