### PR TITLE
#60 adjust documentation on host addresses to refer to IPv4 only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ accepts the following configuration parameters when it is initialized:
           Argument              Default                    Explanation
     =====================  =================  ========================================
     ``library``                               Test library instance or module to host. Mandatory argument.
-    ``host``                ``'127.0.0.1'``   Address to listen. Use ``'0.0.0.0'`` to listen to all available interfaces.
+    ``host``                ``'127.0.0.1'``   Address to listen. Use ``'0.0.0.0'`` to listen to all available IPv4 addresses.
     ``port``                ``8270``          Port to listen. Use ``0`` to select a free port automatically. Can be given as an integer or as a string. The default port ``8270`` is `registered by IANA`__ for remote server usage.
     ``port_file``           ``None``          File to write the port that is used. ``None`` (default) means no such file is written.
     ``allow_stop``          ``'DEPRECATED'``  Deprecated since version 1.1. Use ``allow_remote_stop`` instead.

--- a/src/robotremoteserver.py
+++ b/src/robotremoteserver.py
@@ -55,7 +55,8 @@ class RobotRemoteServer(object):
 
         :param library:     Test library instance or module to host.
         :param host:        Address to listen. Use ``'0.0.0.0'`` to listen
-                            to all available interfaces.
+                            to all available interfaces that have an IPv4
+                            address.
         :param port:        Port to listen. Use ``0`` to select a free port
                             automatically. Can be given as an integer or as
                             a string.


### PR DESCRIPTION
Proposed documentation change to note that 0.0.0.0 only applies to IPv4.