### PR TITLE
Simpleipv6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -243,6 +243,29 @@ using ``stop`` argument on the command line or by using the
 ``stop_remote_server`` function programmatically. Testing and stopping should
 work also with other Robot Framework remote server implementations.
 
+Simple IPv6 Support
+-------------------
+
+RobotRemoteServer instances can bind to IPv6 addresses as well as IPv4 addresses;
+both specific addresses and the 'any available address' equivalent to IPv4's
+'0.0.0.0': '::'.
+
+To use IPv6 addresses, it is necessary to set the class variable `TCPServer.address_family`
+*before* the `import` of `RobotRemoteServer`, as shown in the example below.
+
+.. sourcecode:: python
+
+    import socketserver
+    import socket
+    
+    socketserver.TCPServer.address_family = socket.AF_INET6
+    
+    from robotremoteserver import RobotRemoteServer
+    from mylibrary import MyLibrary
+    
+    RobotRemoteServer (MyLibrary (), host = "::")
+
+
 Listing keywords and viewing documentation
 ------------------------------------------
 

--- a/example/exipv6.py
+++ b/example/exipv6.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# example of how to get RobotRemtoteServer working with IPv6: set up socketserver.TTCPServer.addresse_family
+# class variable before importing RobotRemoteServer. Then use IPv6 notation, rather than IPv4
 
 import sys
 
@@ -12,7 +14,13 @@ from robotremoteserver import RobotRemoteServer
 from examplelibrary import ExampleLibrary
 
 if __name__ == '__main__':
+    # listen on any IPv6 address, including all IPv4 addresses on the host
     #RobotRemoteServer(ExampleLibrary(), host="::", *sys.argv[1:])
+    # listen on local loopback interface
+    #RobotRemoteServer(ExampleLibrary(), host="::1", *sys.argv[1:])
+    # example encoding of IPv4 RFC1918 address as IPv6 address
     #RobotRemoteServer(ExampleLibrary(), host="::ffff:192.168.194.81", *sys.argv[1:])
+    # IPv4 notation will fail
     #RobotRemoteServer(ExampleLibrary(), host="192.168.194.81", *sys.argv[1:])
+    # listen on any IPv4 address
     RobotRemoteServer(ExampleLibrary(), host="::ffff:0.0.0.0", *sys.argv[1:])

--- a/example/exipv6.py
+++ b/example/exipv6.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import sys
+
+import socketserver
+import socket
+
+socketserver.TCPServer.address_family = socket.AF_INET6
+    
+from robotremoteserver import RobotRemoteServer
+
+from examplelibrary import ExampleLibrary
+
+if __name__ == '__main__':
+    #RobotRemoteServer(ExampleLibrary(), host="::", *sys.argv[1:])
+    #RobotRemoteServer(ExampleLibrary(), host="::ffff:192.168.194.81", *sys.argv[1:])
+    #RobotRemoteServer(ExampleLibrary(), host="192.168.194.81", *sys.argv[1:])
+    RobotRemoteServer(ExampleLibrary(), host="::ffff:0.0.0.0", *sys.argv[1:])

--- a/example/tests.robot
+++ b/example/tests.robot
@@ -2,7 +2,7 @@
 Library       Remote    http://${ADDRESS}:${PORT}
 
 *** Variables ***
-${ADDRESS}    127.0.0.1
+${ADDRESS}    localhost
 ${PORT}       8270
 
 *** Test Cases ***

--- a/example/tests.robot
+++ b/example/tests.robot
@@ -2,7 +2,13 @@
 Library       Remote    http://${ADDRESS}:${PORT}
 
 *** Variables ***
-${ADDRESS}    ::1
+# localhost may be a suitable alias for the local IP stack loopback address
+${ADDRESS}    localhost
+# alternatively, use a protocol specific loopback address
+# IPv6 loopback address
+#${ADDRESS}    ::1
+# IPv4 loopback address
+#${ADDRESS}    127.0.0.1
 ${PORT}       8270
 
 *** Test Cases ***

--- a/example/tests.robot
+++ b/example/tests.robot
@@ -2,7 +2,7 @@
 Library       Remote    http://${ADDRESS}:${PORT}
 
 *** Variables ***
-${ADDRESS}    localhost
+${ADDRESS}    ::1
 ${PORT}       8270
 
 *** Test Cases ***

--- a/src/robotremoteserver.py
+++ b/src/robotremoteserver.py
@@ -24,12 +24,6 @@ import sys
 import threading
 import traceback
 
-import socketserver
-import socket
-
-socketserver.TCPServer.address_family = socket.AF_INET6
-    
-
 if sys.version_info < (3,):
     from SimpleXMLRPCServer import SimpleXMLRPCServer
     from StringIO import StringIO
@@ -55,7 +49,7 @@ NON_ASCII = re.compile('[\x80-\xff]')
 
 class RobotRemoteServer(object):
 
-    def __init__(self, library, host='::1', port=8270, port_file=None,
+    def __init__(self, library, host='127.0.0.1', port=8270, port_file=None,
                  allow_stop='DEPRECATED', serve=True, allow_remote_stop=True):
         """Configure and start-up remote server.
 

--- a/src/robotremoteserver.py
+++ b/src/robotremoteserver.py
@@ -55,7 +55,8 @@ class RobotRemoteServer(object):
 
         :param library:     Test library instance or module to host.
         :param host:        Address to listen. Use ``'0.0.0.0'`` to listen
-                            to all available interfaces.
+                            to all available interfaces that have an IPv4
+                            address.
         :param port:        Port to listen. Use ``0`` to select a free port
                             automatically. Can be given as an integer or as
                             a string.

--- a/src/robotremoteserver.py
+++ b/src/robotremoteserver.py
@@ -150,7 +150,7 @@ class RobotRemoteServer(object):
 
     def _log(self, action, log=True, warn=False):
         if log:
-            address = '%s:%s' % self.server_address
+            address = '%s:%s' % self.server_address [:2]
             if warn:
                 print('*WARN*', end=' ')
             print('Robot Framework remote server at %s %s.' % (address, action))

--- a/src/robotremoteserver.py
+++ b/src/robotremoteserver.py
@@ -24,6 +24,12 @@ import sys
 import threading
 import traceback
 
+import socketserver
+import socket
+
+socketserver.TCPServer.address_family = socket.AF_INET6
+    
+
 if sys.version_info < (3,):
     from SimpleXMLRPCServer import SimpleXMLRPCServer
     from StringIO import StringIO
@@ -49,7 +55,7 @@ NON_ASCII = re.compile('[\x80-\xff]')
 
 class RobotRemoteServer(object):
 
-    def __init__(self, library, host='127.0.0.1', port=8270, port_file=None,
+    def __init__(self, library, host='::1', port=8270, port_file=None,
                  allow_stop='DEPRECATED', serve=True, allow_remote_stop=True):
         """Configure and start-up remote server.
 


### PR DESCRIPTION
This branch has two tags:
- ipv6lw is, essentially, documentation on how to use ipv6, with some example code.
- ipv6hw moves the code into robotremoteserver.py. This makes the default behaviour ipv6. Although this behaviour includes ipv4 as a subset, some of the notation changes, making this a breaking change. It would also fail on a platform that had no ipv6. I think that those are now quite rare.

I don't know what extra tests are required for these changes, but I think that the code in example is close to sufficient.

I don't know whether it's a hindrance, but this branch also includes the documentation changes on the semantics of the ipv4 address 0.0.0.0.