### PR TITLE
Update test suite to match latest Robot and Python versions

### DIFF
--- a/test/atest/argument_spec_invalid.robot
+++ b/test/atest/argument_spec_invalid.robot
@@ -29,15 +29,15 @@ Too few arguments when using varargs
     Required Defaults And Varargs
 
 Using arguments when only kwargs accepted
-    [Documentation]  FAIL Keyword 'Remote.Kwargs' expected 0 non-keyword arguments, got 4.
+    [Documentation]  FAIL Keyword 'Remote.Kwargs' expected 0 non-named arguments, got 4.
     Kwargs    normal    args    are    no-no
 
 Too few arguments when kwargs accepted
-    [Documentation]  FAIL Keyword 'Remote.Args And Kwargs' expected 1 to 2 non-keyword arguments, got 0.
+    [Documentation]  FAIL Keyword 'Remote.Args And Kwargs' expected 1 to 2 non-named arguments, got 0.
     Args and kwargs
 
 Too many arguments when kwargs accepted
-    [Documentation]  FAIL Keyword 'Remote.Args And Kwargs' expected 1 to 2 non-keyword arguments, got 7.
+    [Documentation]  FAIL Keyword 'Remote.Args And Kwargs' expected 1 to 2 non-named arguments, got 7.
     Args and kwargs    we    do    not    accept    this    many    args
 
 Missing argument when using kwargs

--- a/test/atest/argument_types.robot
+++ b/test/atest/argument_types.robot
@@ -57,7 +57,7 @@ List-like
     ()    []
     ('Hei', u'\\xe4iti', 63, (), None)    ['Hei', u'\\xe4iti', 63, [], '']
     set(['hello'])    ['hello']
-    xrange(5)    [0, 1, 2, 3, 4]
+    range(5)    [0, 1, 2, 3, 4]
 
 Dictionary
     {}

--- a/test/atest/basic_communication.robot
+++ b/test/atest/basic_communication.robot
@@ -32,9 +32,10 @@ Use multiple times
     ...    LOG 1.1.2 Round 1
     ...    LOG 1.2.2 Round 2
     ...    LOG 1.${COUNT}.2 Round ${COUNT}
-    : FOR    ${i}    IN RANGE    ${COUNT}
-    \    Passing
-    \    Logging    Round ${i + 1}
+    FOR    ${i}    IN RANGE    ${COUNT}
+        Passing
+        Logging    Round ${i + 1}
+    END
 
 Private methods should ne ignored
     [Documentation]    FAIL No keyword with name 'Private Method' found.

--- a/test/atest/kwargs.robot
+++ b/test/atest/kwargs.robot
@@ -61,4 +61,4 @@ Non-string kwargs
 Binary kwargs
     ${tuple} =    Evaluate    ('\x02',)
     ${result} =    Kwargs    a=\x00    b=\x01    c=${tuple}
-    Should Match    ${result}    a:\x00, b:\x01, c:[*'\\x02'] (list)
+    Should be equal    ${result}    a:\x00, b:\x01, c:[b'\\x02'] (list)

--- a/test/atest/logging.robot
+++ b/test/atest/logging.robot
@@ -38,7 +38,7 @@ Multiple messages with different levels
     [Documentation]
     ...    LOG 1:1 INFO Info message
     ...    LOG 1:2 DEBUG Debug message
-    ...    LOG 1:3 INFO Second info\n this time with two lines
+    ...    LOG 1:3 INFO Second info\nthis time with two lines
     ...    LOG 1:4 INFO Third info
     ...    LOG 1:5 WARN Warning
     Multiple Messages With Different Levels

--- a/test/atest/module.robot
+++ b/test/atest/module.robot
@@ -32,9 +32,10 @@ Use multiple times
     ...    LOG 1.1.2 Round 1
     ...    LOG 1.2.2 Round 2
     ...    LOG 1.${COUNT}.2 Round ${COUNT}
-    : FOR    ${i}    IN RANGE    ${COUNT}
-    \    Passing
-    \    Logging    Round ${i + 1}
+    FOR    ${i}    IN RANGE    ${COUNT}
+        Passing
+        Logging    Round ${i + 1}
+    END
 
 Private methods should ne ignored
     [Documentation]    FAIL No keyword with name 'Private Method' found.

--- a/test/atest/returning.robot
+++ b/test/atest/returning.robot
@@ -96,7 +96,7 @@ Dictionary with binary keys is not supported
     {u'\\x00': 'value'}
 
 Dictionary with binary values
-    {'0': u'\\x00', '1': b'\\x01'}
+    {'0': u'\\x00', '1': b'\\xff'}
 
 Dictionary with non-string keys and values
     [Documentation]    XML-RPC supports only strings as keys so must convert them


### PR DESCRIPTION
Please review this pull request and provide relevant feedback on how to properly fix all tests to reastablish a safe starting point for further modifications.

I am looking into issue [#3362](https://github.com/robotframework/robotframework/issues/3362) of Robot framework about loading large keyword libraries. Prototypes are looking promising, but before making any real changes to either side of the interface I need a good set of tests to work from as a base for delivering quality.

The changes in this current pull request are about getting up-to-date with latest versions of Robot and Python. They either fix all but 1 or all but 5 tests, depending on the favoured approach. Remaining failures are caused by bytes versus unicode conflicts and I was unable to find a solution that works in all situations.

**Option 1: Remaining failures 1**
This requires a change in the `_convert()` method in Robot's `Remote.py`. This will, whenever possible, automatically convert bytes to unicode. The remaining failure is a test case that intentionally sends unicode as bytes type. With automatic conversion this will not be received as bytes, but as unicode.

```
    def _convert(self, value):
        if isinstance(value, xmlrpclib.Binary):
            try:                                       ###########
                return bytes(value.data).decode()      # New bit 
            except:                                    #
                return bytes(value.data)
        if is_dict_like(value):
            return DotDict((k, self._convert(v)) for k, v in value.items())
        if is_list_like(value):
            return [self._convert(v) for v in value]
        return value
```

**Option 2: Remaining failures 5**
This is without updating anything on Robot side, so without the _new bit_. I was unable to find a solution to distinguish between the intention of bytes or unicode, so this is the opposite solution to option 1. Bytes are always passed on as bytes, no conversion. This does however mean that the receiving side will need to deal with this on library level.

Of course I would even more appreciate if someone came up with a third options that cleanly separates the two intentions. Please share your thoughts.