### PR TITLE
Support serving multiple libraries by one server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -261,7 +261,7 @@ an output file::
 
 __ http://robotframework.org/robotframework/#built-in-tools
 
-Serving Multiple Libraries
+Serving Multiple Libraries With One Server
 -------
 
 In many cases it maybe be desirable to serve multiple libraries from a single

--- a/README.rst
+++ b/README.rst
@@ -261,6 +261,25 @@ an output file::
 
 __ http://robotframework.org/robotframework/#built-in-tools
 
+Serving Multiple Libraries
+-------
+
+In many cases it maybe be desirable to serve multiple libraries from a single
+remote server. The libraries argument not only accepts a single class type, but
+also can accept a list of classes from which to serve keywords. For example:
+
+.. sourcecode:: python
+  class KeywordLib1:
+    def Keyword1(self):
+      ...
+
+  class KeywordLib2:
+    def Keyword2(self):
+      ...
+
+  if __name__ == "__main__":
+    RobotRemoteServer([KeywordLib1(), KeywordLib2()])
+
 Example
 -------
 

--- a/example/examplelibrary.py
+++ b/example/examplelibrary.py
@@ -34,4 +34,4 @@ class ExampleLibrary(object):
 
 
 if __name__ == '__main__':
-    RobotRemoteServer(ExampleLibrary(), *sys.argv[1:])
+    RobotRemoteServer([ExampleLibrary()], *sys.argv[1:])

--- a/src/robotremoteserver.py
+++ b/src/robotremoteserver.py
@@ -74,7 +74,8 @@ class RobotRemoteServer(object):
                             ``Stop Remote Server`` keyword and
                             ``stop_remote_server`` XML-RPC method.
         """
-        self._library = RemoteLibraryFactory(library)
+        self._library = [RemoteLibraryFactory(library_) 
+                         for library_ in library]
         self._server = StoppableXMLRPCServer(host, int(port))
         self._register_functions(self._server)
         self._port_file = port_file
@@ -171,28 +172,35 @@ class RobotRemoteServer(object):
         return True
 
     def get_keyword_names(self):
-        return self._library.get_keyword_names() + ['stop_remote_server']
+        keywords = ['stop_remote_server']
+        for l in self._library:
+            keywords += l.get_keyword_names()
+        return keywords
 
     def run_keyword(self, name, args, kwargs=None):
         if name == 'stop_remote_server':
             return KeywordRunner(self.stop_remote_server).run_keyword(args, kwargs)
-        return self._library.run_keyword(name, args, kwargs)
+        library_ = next(l for l in self._library if name in l._names)
+        return library_.run_keyword(name, args, kwargs)
 
     def get_keyword_arguments(self, name):
         if name == 'stop_remote_server':
             return []
-        return self._library.get_keyword_arguments(name)
+        library_ = next(l for l in self._library if name in l._names)
+        return library_.get_keyword_arguments(name)
 
     def get_keyword_documentation(self, name):
         if name == 'stop_remote_server':
             return ('Stop the remote server unless stopping is disabled.\n\n'
                     'Return ``True/False`` depending was server stopped or not.')
-        return self._library.get_keyword_documentation(name)
+        library_ = next(l for l in self._library if name in l._names)
+        return library_.get_keyword_documentation(name)
 
     def get_keyword_tags(self, name):
         if name == 'stop_remote_server':
             return []
-        return self._library.get_keyword_tags(name)
+        library_ = next(l for l in self._library if name in l._names)
+        return library_.get_keyword_tags(name)
 
 
 class StoppableXMLRPCServer(SimpleXMLRPCServer):


### PR DESCRIPTION
# Summary
Addresses concerns from PR #47 , by

1. Allowing backward compatibility with previous interface which only supported a single class while still supporting a list of classes.
2. Updating documentation to include section on serving multiple libraries with a single server.

Also updates property from `_library` to `_libraries` to improve clarity for reader.

- [x] new functionality
- [ ] breaking changes
- [x] documentation